### PR TITLE
This adds a “oneselectorperline” option, which I think really helps legibility when selectors become complicated.

### DIFF
--- a/cssbeautify.js
+++ b/cssbeautify.js
@@ -274,7 +274,21 @@ function cssbeautify(style, opt) {
                 continue;
             }
 
-            formatted += ch;
+
+            // Newline for each selector if specified.
+            if (options.oneselectorperline) {
+                if (ch === ',') {
+                    formatted += ch + '\n';
+
+                // Don't append the character if it's whitespace
+                // and the last added character was a newline.
+                } else if ((formatted.slice(-1) !== '\n') || !isWhitespace(ch)) {
+                    formatted += ch;
+                }
+            } else {
+                formatted += ch;
+            }
+
             continue;
         }
 

--- a/index.html
+++ b/index.html
@@ -26,6 +26,8 @@
                 options.openbrace = 'separate-line';
             }
 
+            options.oneselectorperline = document.getElementById("oneselectorperline").checked;
+
             raw = document.getElementById('raw').value;
             beautified = cssbeautify(raw, options);
             document.getElementById('beautified').value = beautified;
@@ -67,6 +69,7 @@
         <label><input checked type="radio" name="openbrace" id="openbrace-end-of-line" onChange='format()'>end of line</label><br>
         <label><input type="radio" name="openbrace" id="openbrace-separate-line" onChange='format()'>separate line</label>
         </p>
+        <p><label><input checked type="checkbox" id="oneselectorperline" onchange="format()">One selector per line</label></p>
     </div>
 
     <br clear="all"/>

--- a/style.css
+++ b/style.css
@@ -51,7 +51,7 @@ textarea {
 .container {
     margin-left: auto;
     margin-right: auto;
-    width: 960px;
+    width: 980px;
 }
 
 .container .raw {
@@ -92,15 +92,20 @@ textarea {
 }
 
 .container .options {
-    width: 140px;
+    width: 160px;
     display: inline;
     float: left;
     margin-left: 10px;
     margin-right: 10px;
 }
 
-.container .options input {
+.container .options input[type=radio] {
     margin: 5px 5px 5px 10px;
+}
+
+.container .options input[type=checkbox] {
+    margin-left: 0;
+    margin-right: 5px;
 }
 
 .footer {

--- a/test.htm
+++ b/test.htm
@@ -28,6 +28,14 @@ pre {
 .fail {
     color: red;
 }
+
+.container .options {
+    margin-left: 20px;
+    float: none;
+}
+.container .options:before {
+    content: "Options: ";
+}
 </style>
 </head>
 <body>
@@ -360,6 +368,28 @@ h1 {
 }
 </pre>
 
+<h2>Newlines between selectors (optional)</h2>
+
+<pre id="selectornewlines" class="options">
+{ oneselectorperline: true }
+</pre>
+
+<pre id="selectornewlines" class="status"></pre>
+
+<pre id="selectornewlines" class="source">
+foo, html bar, this.that:not(#these) {
+    color: blue;
+}
+</pre>
+
+<pre id="selectornewlines" class="ref">
+foo,
+html bar,
+this.that:not(#these) {
+    color: blue;
+}
+</pre>
+
 </div>
 
 <script>
@@ -373,17 +403,19 @@ for (i = 0; i < list.length; i += 1) {
     id = e.id;
     cls = e.getAttribute('class');
     if (typeof id === 'string' && id.length > 0) {
+        if (!data[id]) { data[id] = {}; }
+
         if (cls === 'source') {
-          data[id] = data[id] || {};
           data[id].source = e.innerHTML;
         }
         if (cls === 'ref') {
-          data[id] = data[id] || {};
           data[id].ref = e.innerHTML.replace(/^\s+/, '').replace(/\s+$/, '');
         }
         if (cls === 'status') {
-          data[id] = data[id] || {};
           data[id].status = e;
+        }
+        if (cls === 'options') {
+          eval( "data[id].options = " + e.innerHTML );
         }
     }
 }
@@ -393,7 +425,13 @@ for (name in data) {
     if (data.hasOwnProperty(name)) {
         total += 1;
         test = data[name];
-        test.result = cssbeautify(test.source).replace(/^\s+/, '').replace(/\s+$/, '');
+
+        var args = [test.source];
+        if ( test.options ) {
+            args.push( test.options );
+        }
+
+        test.result = cssbeautify.apply(this,args).replace(/^\s+/, '').replace(/\s+$/, '');
         if (test.result !== test.ref) {
             failures += 1;
             e = document.createElement('pre');


### PR DESCRIPTION
I’ve sent in the online CLA.
