### PR TITLE
Beautify stdin if there are no filename arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ var beautified = cssbeautify('menu{opacity:.7}', {
 });
 ```
 
+## Command line use ##
+
+```
+npm install -g cssbeautify
+cssbeautify style.css # beautified CSS is output to console
+cssbeautify style.css >style.beautified.css # write to file
+curl http://example.com/style.css | cssbeautify # beautify stdin
+```
+
 ## Contributing ##
 
 Contributions are welcomed! Please read the [Contribution Guide](https://github.com/senchalabs/cssbeautify/blob/master/CONTRIBUTING.md) for more info.

--- a/bin/cssbeautify
+++ b/bin/cssbeautify
@@ -25,7 +25,7 @@
 
 /*jslint sloppy:true node:true */
 
-var fs, cssbeautify, fname, content, options, style;
+var fs, cssbeautify, fname, content, options;
 
 fs = require('fs');
 cssbeautify = require('cssbeautify');
@@ -33,16 +33,13 @@ cssbeautify = require('cssbeautify');
 function showUsage() {
     console.log('Usage:');
     console.log('   cssbeautify [options] style.css');
+    console.log('   curl http://example.com/style.css | cssbeautify [options]');
     console.log();
     console.log('Available options:');
     console.log();
     console.log('  -v, --version  Shows program version');
     console.log();
     process.exit(1);
-}
-
-if (process.argv.length <= 2) {
-    showUsage();
 }
 
 options = {};
@@ -67,17 +64,28 @@ process.argv.splice(2).forEach(function (entry) {
     }
 });
 
-if (typeof fname !== 'string') {
-    console.log('Error: no input file.');
-    process.exit(1);
-}
-
-try {
-    content = fs.readFileSync(fname, 'utf-8');
+function beautifyAndOutput(err, content) {
+    var style;
+    if (err) {
+        console.log('Error: ' + err.message);
+        process.exit(1);
+    }
     style = cssbeautify(content);
     console.log(style);
-} catch (e) {
-    console.log('Error: ' + e.message);
-    process.exit(1);
 }
 
+if (typeof fname !== 'string') {
+    content = '';
+    process.stdin.resume();
+    process.stdin.on('data', function(buf) {
+        content += buf;
+    });
+    process.stdin.on('error', function(err) {
+        beautifyAndOutput(err);
+    });
+    process.stdin.on('end', function() {
+        beautifyAndOutput(null, content);
+    });
+} else {
+    fs.readFile(fname, 'utf-8', beautifyAndOutput);
+}


### PR DESCRIPTION
I don't expect you to accept this pull request since I haven't signed and do not want to sign your contribution agreement thing. So this is just here in case anyone is looking for this feature, in which case they can use my fork.

This allows cssbeautify to be used as a filter, for instance calling it from vim over a group of lines, or piping curl's output to cssbeautify, and so on.

```
git clone https://github.com/tremby/cssbeautify.git
cd cssbeautify
sudo npm install -g
```
