### PR TITLE
Do not require that all new patches break tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Before we can accept any contributions, you need to sign [Contributor License Ag
 
 Make sure that your code passes [JSLint](http://jslint.com) checks.
 
-Make sure your patch does break existing tests (open <code>test/index.html</code> in a web browser).
+Make sure your patch does not break existing tests (open <code>test/index.html</code> in a web browser).
 
 If you add a new feature, create a new test associated with that. Feature or enhancement pull request without a corresponding test will **not** be merged.
 
@@ -21,4 +21,3 @@ If you add a new feature, create a new test associated with that. Feature or enh
 For the actual contribution, please use [Github pull request](http://help.github.com/pull-requests/) workflow.
 
 Please do not create a pull request for multiple unrelated commits. It is strongly recommended to create a topic branch and make the commits as atomic as possible for the merge. This makes it easy to review all the changes.
-


### PR DESCRIPTION
It does not seem to be in keeping with the spirit of the document, so I
thought I would fix it.

(Also removes an extra blank line from the end.)
