### PR TITLE
Stricter checking for node.js

### DIFF
--- a/cssbeautify.js
+++ b/cssbeautify.js
@@ -458,7 +458,7 @@
         return formatted;
     }
 
-    if (typeof exports !== 'undefined') {
+    if (typeof exports !== 'undefined' && typeof process !== 'undefined') {
         // Node.js module.
         module.exports = exports = cssbeautify;
     } else if (typeof window === 'object') {


### PR DESCRIPTION
We need to also check to see if the 'process' variable is defined because some front-end frameworks (like Thorax) use the 'module'  or 'exports' keywords.
