### PR TITLE
Fix improper comparison for undefined

### DIFF
--- a/assets/format.js
+++ b/assets/format.js
@@ -28,7 +28,7 @@ function format() {
             options.autosemicolon = true;
         }
 
-        if (typeof editor === undefined) {
+        if (typeof editor === 'undefined') {
             raw = document.getElementById('raw').value;
         } else {
             raw = editor.getValue();
@@ -36,7 +36,7 @@ function format() {
 
         beautified = cssbeautify(raw, options);
 
-        if (typeof viewer === undefined) {
+        if (typeof viewer === 'undefined') {
             document.getElementById('beautified').value = beautified;
         } else {
             viewer.setValue(beautified);


### PR DESCRIPTION
``` javascript
// This is false
typeof undefined === undefined
// This is true
typeof undefined === "undefined"
// Because
typeof typeof anything === "string" // is true
```
