### PR TITLE
Expose options via command line

### DIFF
--- a/bin/cssbeautify
+++ b/bin/cssbeautify
@@ -25,10 +25,15 @@
 
 /*jslint sloppy:true node:true */
 
-var fs, cssbeautify, fname, content, options, style;
+var fs, path, cssbeautify, file_list, content, options, style, opt;
 
 fs = require('fs');
-cssbeautify = require('cssbeautify');
+path = require('path');
+
+//cssbeautify = require('cssbeautify');
+cssbeautify = require('' + path.join(__dirname, '..', 'cssbeautify.js'));
+
+
 
 function showUsage() {
     console.log('Usage:');
@@ -36,7 +41,26 @@ function showUsage() {
     console.log();
     console.log('Available options:');
     console.log();
-    console.log('  -v, --version  Shows program version');
+    //          0         1         2         3         4         5         6         7
+    //          01234567890123456789012345678901234567890123456789012345678901234567890123456789
+    //          |                      |                                                       |
+    console.log('  -2                  Shortcut for -i/--indent 2');
+    console.log('  -4                  Shortcut for -i/--indent 4');
+    console.log('  --auto-semicolumn   Auto add semicolumns');
+    console.log('  -n | --brace-on-new-line')
+    console.log('                      Put braces on a separate line');
+    console.log('  -f FILE | --file FILE');
+    console.log('                      Input file(s)');
+    console.log('  -i INDENT | --indent INDENT');
+    console.log('                      Indentation');
+    console.log('  --brace-on-same-line');
+    console.log('                      Keep braces on the same (last) line of selector');
+    console.log('  --no-auto-semicolumn  Do not auto add semicolons');
+    console.log('  --no-separate-selectors');
+    console.log('                      Do not separate selectors on commas');
+    console.log('  -s | --separate-selectors');
+    console.log('                      Seperate selectors on commas');
+    console.log('  -v | --version      Shows program version');
     console.log();
     process.exit(1);
 }
@@ -46,38 +70,95 @@ if (process.argv.length <= 2) {
 }
 
 options = {};
+file_list = [];
 
-process.argv.splice(2).forEach(function (entry) {
+// Initialize configuration
+options.separateSelectors = false;
+options.indent = '    ';
+options.openbrace = 'end-of-line';
+options.autosemicolon = true;
 
-    if (entry === '-h' || entry === '--help') {
+indent_number = -1;
+
+for (var i=2; i<process.argv.length; i++) {
+
+    opt = process.argv[i];
+
+    if (opt === '-h' || opt === '--help') {
         showUsage();
-    } else if (entry === '-v' || entry === '--version') {
+    } else if (opt === '-v' || opt === '--version') {
         // Keep in sync with package.json
         console.log('CSS Beautify version 0.3.0');
         console.log();
         process.exit(0);
-    } else if (entry.slice(0, 2) === '--') {
-        console.log('Error: unknown option ' + entry + '.');
-        process.exit(1);
-    } else if (typeof fname === 'string') {
-        console.log('Error: more than one input file.');
+    } else if (opt === '-f' || opt === '--file') {
+        i++;
+        file_list.push(process.argv[i]);
+    } else if (opt === '-i' || opt === '--indent') {
+        i++;
+        optval = process.argv[i];
+        indent_number = parseInt(optval, 10);
+        if (isNaN(indent_number)) {
+            console.log('Error: invalid indent');
+            process.exit(1);
+        }
+        console.log('Indent: ' + indent_number);
+    } else if (opt === '-2') {
+        options.indent = '  ';
+        indent_number = -1;
+    } else if (opt === '-4') {
+        options.indent = '    ';
+        indent_number = -1;
+    } else if (opt === '-n' || opt === '--brace-on-new-line') {
+        options.openbrace = '';
+    } else if (opt === '--brace-on-same-line') {
+        options.openbrace = 'end-of-line';
+    } else if (opt === '--auto-semicolumn') {
+        options.autosemicolon = true;
+    } else if (opt === '--no-auto-semicolumn') {
+        options.autosemicolon = false;
+    } else if (opt === '-s' || opt === '--separate-selectors') {
+        options.separateSelectors = true;
+    } else if (opt === '--no-separate-selectors') {
+        options.separateSelectors = false;
+    } else if (opt.slice(0, 2) === '--') {
+        console.log('Error: unknown option ' + opt + '.');
         process.exit(1);
     } else {
-        fname = entry;
+        file_list.push(opt);
     }
-});
+}
 
-if (typeof fname !== 'string') {
+if (file_list.length === 0) {
     console.log('Error: no input file.');
     process.exit(1);
 }
 
-try {
-    content = fs.readFileSync(fname, 'utf-8');
-    style = cssbeautify(content);
-    console.log(style);
-} catch (e) {
-    console.log('Error: ' + e.message);
-    process.exit(1);
+if (indent_number >= 0) {
+    tmp = '';
+    for (i=0; i<indent_number; i++) {
+        tmp += ' ';
+    }
+    options.indent = tmp;
 }
+
+for (i in file_list) {
+    try {
+        if (file_list[i] == '-') {
+            content = fs.readFileSync('/dev/stdin', 'utf-8');
+        } else {
+            content = fs.readFileSync(file_list[i], 'utf-8');
+        }
+        style = cssbeautify(content, options);
+        console.log(style);
+    } catch (e) {
+        console.log('Error: ' + e.message);
+        process.exit(1);
+    }
+}
+
+
+/*
+ # vi: ts=4 sw=4 et syntax=javascript :
+ */
 

--- a/cssbeautify.js
+++ b/cssbeautify.js
@@ -322,6 +322,11 @@
                 }
 
                 formatted += ch;
+
+                if (ch === ',' && options.separateSelectors == true) {
+                    formatted += '\n';
+                }
+
                 continue;
             }
 
@@ -467,3 +472,9 @@
     }
 
 }());
+
+
+/*
+ # vi: ts=4 sw=4 et syntax=javascript :
+ */
+


### PR DESCRIPTION
Extend command line in order to expose more configuration options.

Add an option for split CSS selectors on comma.