### PR TITLE
Enable Web Worker support

### DIFF
--- a/cssbeautify.js
+++ b/cssbeautify.js
@@ -464,6 +464,9 @@
     } else if (typeof window === 'object') {
         // Browser loading.
         window.cssbeautify = cssbeautify;
+    } else if (self instanceof WorkerGlobalScope) {
+        // Web worker.
+        self.cssbeautify = cssbeautify;
     }
 
 }());


### PR DESCRIPTION
This commit allows the library to be imported within the context of a web worker. In a web worker, when a script is imported it is outside of the browser's scope and does not have access to `window`. Data must be passed back and forth between the main and worker thread(s).

Within the Worker, the `self` should be a sub-type of the `WorkerGlobalScope` object. The specific sub-type depends on the type of worker - but all workers scope are based on the former. Registering the library to `self.cssbeautify` allows worker's code to access it via `this.cssbeautify`.